### PR TITLE
Bumped version to 2.6.4 due to mistake in preparing release of 2.6.3 that could not be reversed on the developer platform.

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "novastar-controller",
-	"version": "2.6.3",
+	"version": "2.6.4",
 	"main": "index.js",
 	"type": "module",
 	"scripts": {


### PR DESCRIPTION
Bumped version to 2.6.4 due to mistake in preparing release of 2.6.3 that could not be reversed on the developer platform.